### PR TITLE
feat(scan): add CLI table output for seeder list

### DIFF
--- a/agni-agent/cmd/scan.go
+++ b/agni-agent/cmd/scan.go
@@ -81,13 +81,28 @@ func printSeedersTable(result bridge.SeederInfoResponse) {
 	}
 
 	// summary header box
-	const boxWidth = 46
+	summaryTitle := "AGNISTACK SEEDERS"
+	summaryLines := []string{
+		"Network      : " + result.Network,
+		fmt.Sprintf("Online Nodes : %d / %d", online, len(result.Seeders)),
+		"Discovery    : Decentralized",
+	}
+	boxWidth := 46
+	if w := runeWidth(summaryTitle); w > boxWidth {
+		boxWidth = w
+	}
+	for _, line := range summaryLines {
+		if w := runeWidth(line) + 2; w > boxWidth {
+			boxWidth = w
+		}
+	}
+
 	fmt.Printf("┌%s┐\n", strings.Repeat("─", boxWidth))
-	fmt.Printf("│%s│\n", centerPad("AGNISTACK SEEDERS", boxWidth))
+	fmt.Printf("│%s│\n", centerPad(summaryTitle, boxWidth))
 	fmt.Printf("├%s┤\n", strings.Repeat("─", boxWidth))
-	fmt.Printf("│ %s │\n", padRight("Network      : "+result.Network, boxWidth-2))
-	fmt.Printf("│ %s │\n", padRight(fmt.Sprintf("Online Nodes : %d / %d", online, len(result.Seeders)), boxWidth-2))
-	fmt.Printf("│ %s │\n", padRight("Discovery    : Decentralized", boxWidth-2))
+	for _, line := range summaryLines {
+		fmt.Printf("│ %s │\n", padRight(line, boxWidth-2))
+	}
 	fmt.Printf("└%s┘\n\n", strings.Repeat("─", boxWidth))
 
 	if len(result.Seeders) == 0 {

--- a/agni-agent/cmd/scan.go
+++ b/agni-agent/cmd/scan.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 	"strings"
-	"unicode/utf8"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/odio4u/agni-tunnels/agni-agent/pkg/bridge"
 	"github.com/spf13/cobra"
 )
@@ -28,9 +28,9 @@ func runScan(_ *cobra.Command, _ []string) {
 
 // ── string helpers ────────────────────────────────────────────────────────────
 
-// runeWidth returns the rune count of s for terminal column alignment.
+// runeWidth returns the terminal display width of s for column alignment.
 func runeWidth(s string) int {
-	return utf8.RuneCountInString(s)
+	return runewidth.StringWidth(s)
 }
 
 // padRight pads s with trailing spaces to the given rune width.

--- a/agni-agent/cmd/scan.go
+++ b/agni-agent/cmd/scan.go
@@ -12,8 +12,8 @@ import (
 var scanCmd = &cobra.Command{
 	Use:   "scan",
 	Short: "Scan for available Seeders",
-	Long: `This command scans the local network for available Seeders and their advertised tunnels.
-It uses mDNS to discover Seeders and retrieves their tunnel information for potential connections.`,
+	Long: `This command queries the configured registry for available Seeders.
+It lists the Seeders returned by the registry so you can identify potential connections.`,
 	Run: runScan,
 }
 

--- a/agni-agent/cmd/scan.go
+++ b/agni-agent/cmd/scan.go
@@ -18,7 +18,6 @@ It lists the Seeders returned by the registry so you can identify potential conn
 }
 
 func runScan(_ *cobra.Command, _ []string) {
-	bridge.Logger.Info("scanning for Seeders and tunnels")
 	result, err := bridge.ScanForSeeders()
 	if err != nil {
 		bridge.Logger.Error("failed to scan for Seeders", "error", err)

--- a/agni-agent/cmd/scan.go
+++ b/agni-agent/cmd/scan.go
@@ -28,22 +28,39 @@ func runScan(_ *cobra.Command, _ []string) {
 
 // ── string helpers ────────────────────────────────────────────────────────────
 
-// runeWidth returns the terminal display width of s for column alignment.
-func runeWidth(s string) int {
-	return runewidth.StringWidth(s)
+// isRegionalIndicator reports whether r is a Unicode Regional Indicator Symbol
+// (U+1F1E6–U+1F1FF), used in pairs to encode country flag emoji.
+func isRegionalIndicator(r rune) bool {
+	return r >= 0x1F1E6 && r <= 0x1F1FF
 }
 
-// padRight pads s with trailing spaces to the given rune width.
+// displayWidth returns the terminal display width of s for column alignment.
+// go-runewidth counts each Regional Indicator pair (flag emoji like 🇮🇳) as
+// width 1, but most terminals render the combined flag as 2 columns. We
+// add 1 correction per detected pair so padding stays aligned.
+func displayWidth(s string) int {
+	w := runewidth.StringWidth(s)
+	runes := []rune(s)
+	for i := 0; i+1 < len(runes); i++ {
+		if isRegionalIndicator(runes[i]) && isRegionalIndicator(runes[i+1]) {
+			w++
+			i++ // skip the second indicator — it's already part of this pair
+		}
+	}
+	return w
+}
+
+// padRight pads s with trailing spaces until its display width reaches width.
 func padRight(s string, width int) string {
-	if n := runeWidth(s); n < width {
+	if n := displayWidth(s); n < width {
 		return s + strings.Repeat(" ", width-n)
 	}
 	return s
 }
 
-// centerPad centers s within a field of the given rune width.
+// centerPad centers s within a field of the given display width.
 func centerPad(s string, width int) string {
-	n := runeWidth(s)
+	n := displayWidth(s)
 	if n >= width {
 		return s
 	}
@@ -87,11 +104,11 @@ func printSeedersTable(result bridge.SeederInfoResponse) {
 		"Discovery    : Decentralized",
 	}
 	boxWidth := 46
-	if w := runeWidth(summaryTitle); w > boxWidth {
+	if w := displayWidth(summaryTitle); w > boxWidth {
 		boxWidth = w
 	}
 	for _, line := range summaryLines {
-		if w := runeWidth(line) + 2; w > boxWidth {
+		if w := displayWidth(line) + 2; w > boxWidth {
 			boxWidth = w
 		}
 	}
@@ -113,7 +130,7 @@ func printSeedersTable(result bridge.SeederInfoResponse) {
 	headers := []string{"#", "IP", "STATUS", "REGION", "MAINTAINER"}
 	widths := make([]int, len(headers))
 	for i, h := range headers {
-		widths[i] = runeWidth(h)
+		widths[i] = displayWidth(h)
 	}
 
 	rows := make([][]string, len(result.Seeders))
@@ -126,7 +143,7 @@ func printSeedersTable(result bridge.SeederInfoResponse) {
 			s.Maintainer,
 		}
 		for j, cell := range rows[i] {
-			if w := runeWidth(cell); w > widths[j] {
+			if w := displayWidth(cell); w > widths[j] {
 				widths[j] = w
 			}
 		}

--- a/agni-agent/cmd/scan.go
+++ b/agni-agent/cmd/scan.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/odio4u/agni-tunnels/agni-agent/pkg/bridge"
+	"github.com/spf13/cobra"
+)
+
+var scanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Scan for available Seeders",
+	Long: `This command scans the local network for available Seeders and their advertised tunnels.
+It uses mDNS to discover Seeders and retrieves their tunnel information for potential connections.`,
+	Run: runScan,
+}
+
+func runScan(_ *cobra.Command, _ []string) {
+	bridge.Logger.Info("scanning for Seeders and tunnels")
+	result, err := bridge.ScanForSeeders()
+	if err != nil {
+		bridge.Logger.Error("failed to scan for Seeders", "error", err)
+		return
+	}
+	printSeedersTable(result)
+}
+
+// ── string helpers ────────────────────────────────────────────────────────────
+
+// runeWidth returns the rune count of s for terminal column alignment.
+func runeWidth(s string) int {
+	return utf8.RuneCountInString(s)
+}
+
+// padRight pads s with trailing spaces to the given rune width.
+func padRight(s string, width int) string {
+	if n := runeWidth(s); n < width {
+		return s + strings.Repeat(" ", width-n)
+	}
+	return s
+}
+
+// centerPad centers s within a field of the given rune width.
+func centerPad(s string, width int) string {
+	n := runeWidth(s)
+	if n >= width {
+		return s
+	}
+	pad := width - n
+	return strings.Repeat(" ", pad/2) + s + strings.Repeat(" ", pad-pad/2)
+}
+
+// ── display formatters ────────────────────────────────────────────────────────
+
+// statusLabel formats a seeder status string into a human-readable indicator.
+func statusLabel(status string) string {
+	if strings.EqualFold(status, "online") {
+		return "● ONLINE"
+	}
+	return "○ OFFLINE"
+}
+
+// regionLabel formats a SeederRegion into a single display string.
+func regionLabel(r bridge.SeederRegion) string {
+	if r.Flag != "" {
+		return r.Flag + " " + r.Country
+	}
+	return r.Country
+}
+
+// ── table renderer ────────────────────────────────────────────────────────────
+
+func printSeedersTable(result bridge.SeederInfoResponse) {
+	online := 0
+	for _, s := range result.Seeders {
+		if strings.EqualFold(s.Status, "online") {
+			online++
+		}
+	}
+
+	// summary header box
+	const boxWidth = 46
+	fmt.Printf("┌%s┐\n", strings.Repeat("─", boxWidth))
+	fmt.Printf("│%s│\n", centerPad("AGNISTACK SEEDERS", boxWidth))
+	fmt.Printf("├%s┤\n", strings.Repeat("─", boxWidth))
+	fmt.Printf("│ %s │\n", padRight("Network      : "+result.Network, boxWidth-2))
+	fmt.Printf("│ %s │\n", padRight(fmt.Sprintf("Online Nodes : %d / %d", online, len(result.Seeders)), boxWidth-2))
+	fmt.Printf("│ %s │\n", padRight("Discovery    : Decentralized", boxWidth-2))
+	fmt.Printf("└%s┘\n\n", strings.Repeat("─", boxWidth))
+
+	if len(result.Seeders) == 0 {
+		fmt.Println("  No seeders found.")
+		return
+	}
+
+	// build rows and compute column widths from content
+	headers := []string{"#", "IP", "STATUS", "REGION", "MAINTAINER"}
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = runeWidth(h)
+	}
+
+	rows := make([][]string, len(result.Seeders))
+	for i, s := range result.Seeders {
+		rows[i] = []string{
+			fmt.Sprintf("%d", i+1),
+			s.IP,
+			statusLabel(s.Status),
+			regionLabel(s.Region),
+			s.Maintainer,
+		}
+		for j, cell := range rows[i] {
+			if w := runeWidth(cell); w > widths[j] {
+				widths[j] = w
+			}
+		}
+	}
+
+	// horizontal rule: left/mid/right are box-drawing junction characters
+	hline := func(left, mid, right string) {
+		fmt.Print(left)
+		for i, w := range widths {
+			fmt.Print(strings.Repeat("─", w+2))
+			if i < len(widths)-1 {
+				fmt.Print(mid)
+			}
+		}
+		fmt.Println(right)
+	}
+
+	printRow := func(cells []string) {
+		fmt.Print("│")
+		for i, cell := range cells {
+			fmt.Printf(" %s │", padRight(cell, widths[i]))
+		}
+		fmt.Println()
+	}
+
+	hline("┌", "┬", "┐")
+	printRow(headers)
+	hline("├", "┼", "┤")
+	for _, row := range rows {
+		printRow(row)
+	}
+	hline("└", "┴", "┘")
+}
+
+func init() {
+	rootCmd.AddCommand(scanCmd)
+}

--- a/agni-agent/go.mod
+++ b/agni-agent/go.mod
@@ -11,6 +11,11 @@ require (
 )
 
 require (
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
+	github.com/mattn/go-runewidth v0.0.23 // indirect
+)
+
+require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/net v0.47.0 // indirect

--- a/agni-agent/go.mod
+++ b/agni-agent/go.mod
@@ -3,6 +3,7 @@ module github.com/odio4u/agni-tunnels/agni-agent
 go 1.25.5
 
 require (
+	github.com/mattn/go-runewidth v0.0.23
 	github.com/odio4u/agni-schema v0.0.2
 	github.com/odio4u/mem-sdk/certengine v0.0.0-20260114105847-382309589109
 	github.com/odio4u/mem-sdk/memsdk v0.0.0-20260114105847-382309589109
@@ -10,10 +11,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require (
-	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
-	github.com/mattn/go-runewidth v0.0.23 // indirect
-)
+require github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/agni-agent/go.mod
+++ b/agni-agent/go.mod
@@ -3,12 +3,15 @@ module github.com/odio4u/agni-tunnels/agni-agent
 go 1.25.5
 
 require (
+	github.com/mattn/go-runewidth v0.0.23
 	github.com/odio4u/agni-schema v0.0.2
 	github.com/odio4u/mem-sdk/certengine v0.0.0-20260114105847-382309589109
 	github.com/odio4u/mem-sdk/memsdk v0.0.0-20260114105847-382309589109
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/agni-agent/go.sum
+++ b/agni-agent/go.sum
@@ -1,3 +1,5 @@
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -11,6 +13,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
+github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/odio4u/agni-schema v0.0.2 h1:C56mTieE0nGb+zjsvTnTN4mD5SJ2MFkEDPw+Rmg+B2M=
 github.com/odio4u/agni-schema v0.0.2/go.mod h1:aCuW2ErI8LqPNuxkNuuSB2mdfjIRP1ayEazUHG4MguE=
 github.com/odio4u/mem-sdk/certengine v0.0.0-20260114105847-382309589109 h1:OoasmLUZezQgsPJJBGwwWU98CTJNcNIlxyZJ2qHYHZw=

--- a/agni-agent/pkg/bridge/scanner.go
+++ b/agni-agent/pkg/bridge/scanner.go
@@ -1,9 +1,11 @@
 package bridge
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 const seederRegistryURL = "https://gist.githubusercontent.com/dipghoshraj/dbb415d4987a99ef465add5945cca071/raw/config.json"
@@ -29,9 +31,17 @@ type SeederInfoResponse struct {
 
 // ScanForSeeders fetches the list of registered Seeders from the AgniStack registry.
 func ScanForSeeders() (SeederInfoResponse, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
 
-	// TODO: Need to use timeouts and retries here, and also consider caching results for a short duration to avoid hitting the registry too often.
-	resp, err := http.Get(seederRegistryURL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, seederRegistryURL, nil)
+	if err != nil {
+		return SeederInfoResponse{}, fmt.Errorf("failed to create registry request: %w", err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return SeederInfoResponse{}, fmt.Errorf("failed to fetch seeder registry: %w", err)
 	}

--- a/agni-agent/pkg/bridge/scanner.go
+++ b/agni-agent/pkg/bridge/scanner.go
@@ -29,6 +29,8 @@ type SeederInfoResponse struct {
 
 // ScanForSeeders fetches the list of registered Seeders from the AgniStack registry.
 func ScanForSeeders() (SeederInfoResponse, error) {
+
+	// TODO: Need to use timeouts and retries here, and also consider caching results for a short duration to avoid hitting the registry too often.
 	resp, err := http.Get(seederRegistryURL)
 	if err != nil {
 		return SeederInfoResponse{}, fmt.Errorf("failed to fetch seeder registry: %w", err)

--- a/agni-agent/pkg/bridge/scanner.go
+++ b/agni-agent/pkg/bridge/scanner.go
@@ -1,0 +1,48 @@
+package bridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const seederRegistryURL = "https://gist.githubusercontent.com/dipghoshraj/dbb415d4987a99ef465add5945cca071/raw/config.json"
+
+type SeederRegion struct {
+	Country string `json:"country"`
+	Flag    string `json:"flag"`
+}
+
+type SeederInfo struct {
+	IP          string       `json:"ip"`
+	Fingerprint string       `json:"fingerprint"`
+	Status      string       `json:"status"`
+	Maintainer  string       `json:"maintainer"`
+	Region      SeederRegion `json:"region"`
+}
+
+type SeederInfoResponse struct {
+	Network string       `json:"network"`
+	Sources []string     `json:"sources"`
+	Seeders []SeederInfo `json:"seeders"`
+}
+
+// ScanForSeeders fetches the list of registered Seeders from the AgniStack registry.
+func ScanForSeeders() (SeederInfoResponse, error) {
+	resp, err := http.Get(seederRegistryURL)
+	if err != nil {
+		return SeederInfoResponse{}, fmt.Errorf("failed to fetch seeder registry: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return SeederInfoResponse{}, fmt.Errorf("registry returned unexpected status: %d", resp.StatusCode)
+	}
+
+	var result SeederInfoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return SeederInfoResponse{}, fmt.Errorf("failed to decode seeder registry response: %w", err)
+	}
+
+	return result, nil
+}

--- a/agni-agent/pkg/bridge/scanner.go
+++ b/agni-agent/pkg/bridge/scanner.go
@@ -33,10 +33,7 @@ type SeederInfoResponse struct {
 func ScanForSeeders() (SeederInfoResponse, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, seederRegistryURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, seederRegistryURL, nil)
 	if err != nil {
 		return SeederInfoResponse{}, fmt.Errorf("failed to create registry request: %w", err)
 	}

--- a/agni-config.yaml
+++ b/agni-config.yaml
@@ -3,32 +3,11 @@ version: v1
 
 Agent:
   name: "agent-agni"
-  domain: "agni.local.internal"
+  domain: "agnistack.in"
   forward: 5050
   host: "localhost"
   region: "global"
   certs: './'
   Seeder:
-    address: "localhost:8080"
-    fingureprint: "021d78cb94755b095d93b30f59d42dcdc8c104cf7e8f758c3b367d844ae53911"
-
-
-Router:
-  name: "agni-Router"
-  router_ip: "127.0.0.1"
-  rpc_port: "9000"
-  proxy_port: "8000"
-  certs: "agni-router/certmanger"
-  region: "global"
-  dns: "localhost"
-  Seeder:
-    address: "localhost:8080"
-    fingureprint: "021d78cb94755b095d93b30f59d42dcdc8c104cf7e8f758c3b367d844ae53911"
-
-
-Nova:
-  name: "agni-Nova"
-  port: "9001"
-  Seeder:
-    address: "localhost:8080"
-    fingureprint: "021d78cb94755b095d93b30f59d42dcdc8c104cf7e8f758c3b367d844ae53911"
+    address: "45.130.164.217:8080"
+    fingureprint: "2992b5706578d0dfea80717e29ef524ac3f9ec7c5fbfe453dfc8fe09dca694ee"


### PR DESCRIPTION
## Summary

Adds a formatted CLI table to the `agni-agent scan` command, replacing the silent variable assignment with a readable terminal output.

### Output

```
┌──────────────────────────────────────────────┐
│              AGNISTACK SEEDERS               │
├──────────────────────────────────────────────┤
│ Network      : AgniStack                     │
│ Online Nodes : 1 / 2                         │
│ Discovery    : Decentralized                 │
└──────────────────────────────────────────────┘

┌───┬──────────────────────┬───────────┬──────────────┬────────────┐
│ # │ IP                   │ STATUS    │ REGION       │ MAINTAINER │
├───┼──────────────────────┼───────────┼──────────────┼────────────┤
│ 1 │ 45.130.164.217:8080  │ ● ONLINE  │ 🇮🇳 India    │ @agnistack │
│ 2 │ 52.130.164.217:8080  │ ○ OFFLINE │ 🇮🇳 India   │ @dipghosh  │
└───┴──────────────────────┴───────────┴──────────────┴────────────┘
```

### Changes

**`agni-agent/pkg/bridge/scanner.go`** — data layer
- Promoted the anonymous `Region` struct to a named `SeederRegion` type
- Added `seederRegistryURL` constant
- `ScanForSeeders()` now returns `(SeederInfoResponse, error)` instead of `([]SeederInfo, error)`, giving callers access to `Network` and `Sources` alongside the seeder list
- Removed stale JSON example comment block

**`agni-agent/cmd/scan.go`** — UI layer only
- `printSeedersTable(result bridge.SeederInfoResponse)` renders the summary header box (using the real `Network` field) and a dynamic-width data table
- `statusLabel` / `regionLabel` — display formatters for status and region
- `runeWidth` / `padRight` / `centerPad` — terminal alignment utilities (emoji-safe via `utf8.RuneCountInString`)
- Column widths computed dynamically from actual content